### PR TITLE
Update workflow and Makefile

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,6 +18,12 @@ jobs:
         with:
           ocaml-compiler: ocaml-base-compiler.5.0.0
 
+      - name: Install Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
       - name: Cache opam packages
         uses: actions/cache@v3
         with:
@@ -54,6 +60,12 @@ jobs:
         uses: ocaml/setup-ocaml@v2
         with:
           ocaml-compiler: ocaml-base-compiler.5.0.0
+
+      - name: Install Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
 
       - name: Cache opam packages
         uses: actions/cache@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Install OCaml and opam for Miking
         uses: ocaml/setup-ocaml@v2

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,8 @@
   test-tune\
   test-sundials\
   test-ipopt\
-  test-accelerate
+  test-accelerate\
+  test-jvm
 
 all: build
 
@@ -87,7 +88,8 @@ test-all:\
   test-compile\
   test-run\
   test-js\
-	test-tune
+  test-tune\
+  test-jvm
 	@./make.sh lint
 
 # The same as test-all but prunes utests whose external dependencies are not met
@@ -158,6 +160,9 @@ test-ipopt: build
 
 test-accelerate: build
 	@$(MAKE) -s -f test-accelerate.mk
+
+test-jvm: build
+	@$(MAKE) -s -f test-jvm.mk
 
 test-js: install-boot
 	@$(MAKE) -s -f test-js.mk

--- a/test-files.mk
+++ b/test-files.mk
@@ -1,11 +1,16 @@
-# All relevant source files to include in the tests
-src_files_all =\
+# All relevant source files to include in the tests (plus Java tests)
+src_files_all_tmp =\
 	$(wildcard stdlib/*.mc)\
 	$(wildcard stdlib/**/*.mc)\
 	$(wildcard test/mexpr/*.mc)\
 	$(wildcard test/mlang/*.mc)\
 	$(wildcard test/py/*.mc)
 
+# Exclude the tests in the JVM directory, as they depend on Java being
+# installed.
+jvm_files = $(wildcard stdlib/jvm/*.mc)
+src_files_all =\
+	$(filter-out $(jvm_files), $(src_files_all_tmp))
 
 # These programs has special external dependencies which might be tedious to
 # install or are mutually exclusive with other dependencies.

--- a/test-jvm.mk
+++ b/test-jvm.mk
@@ -1,0 +1,8 @@
+include test-files.mk
+
+.PHONY: all $(jvm_files)
+
+all: $(jvm_files)
+
+$(jvm_files):
+	@./make.sh compile-test $@ "build/mi compile --test --disable-optimizations --disable-prune-utests"


### PR DESCRIPTION
Makes the workflow install Java (+ minor version fix) and ensures that the Java tests are only run on `make test-all` so users can still run `make test` without having to install Java.